### PR TITLE
Use ARCH_INDEPENDENT option that is introduced in CMake 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,15 @@ if(UTF8_INSTALL)
         set(DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/utf8cpp)
     endif()
 
+    if(${CMAKE_VERSION} VERSION_GREATER "3.14")
+        set(OPTIONAL_ARCH_INDEPENDENT "ARCH_INDEPENDENT")
+    endif()
+    
     write_basic_package_version_file(
         ${CMAKE_CURRENT_BINARY_DIR}/utf8cppConfigVersion.cmake
         VERSION ${PROJECT_VERSION}
         COMPATIBILITY SameMajorVersion
+        ${OPTIONAL_ARCH_INDEPENDENT}
     )
 
     configure_package_config_file(


### PR DESCRIPTION
Since the utf8-cpp is header-only library, it needs to be arch-independent. For CMake 3.14 or later, the ARCH_INDEPENDENT option is useful for header-only libraries that improves compatibility on different architectures.

Ref: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file